### PR TITLE
token limit bug

### DIFF
--- a/core.py
+++ b/core.py
@@ -49,7 +49,6 @@ def generate_output(prompt: str) -> str:
                 "temperature": 0.4,
                 "top_p": 1,
                 "top_k": 32,
-                "max_output_tokens": 8192,
             },
         )
 


### PR DESCRIPTION
Here in the code 
       
        response = client.models.generate_content(
            model="gemini-2.5-flash",
            contents=full_prompt,
            config={
                "temperature": 0.4,
                "top_p": 1,
                "top_k": 32,
                "max_output_tokens": 8192,
            },
        )

max output token value is set to 8192 leading to limited output by LLM 
The problem arises when the html code provided by the LLM exceeds the token count which truncates the output 


eg:here i tried it and it gave this result

      requestAnimationFrame(update);
        }

        // Initialize planes
        for
-------------------------
✅ Web app saved successfully as 'submissions/submission_om.html'.
(venv) om@GigaChad prompt-wars-cli %

here the code is truncated in between itself as we can see,the same is code being saves in submissions and will not generate any output

FIX

 response = client.models.generate_content(
            model="gemini-2.5-flash",
            contents=full_prompt,
            config={
                "temperature": 0.4,
                "top_p": 1,
                "top_k": 32,
               
                
            },

remove max_output_tokens

this is my github issue please use proper markup for it

Closes #1 